### PR TITLE
Fix Carthage binary JSON

### DIFF
--- a/MUXCore.json
+++ b/MUXCore.json
@@ -1,4 +1,6 @@
 {
-	"3.9.0": "https://github.com/muxinc/stats-sdk-objc/releases/download/v3.8.0/MUXCore.xcframework.zip"
+	"3.7.0": "https://github.com/muxinc/stats-sdk-objc/releases/download/v3.7.0/MUXCore.xcframework.zip",
+	"3.8.0": "https://github.com/muxinc/stats-sdk-objc/releases/download/v3.8.0/MUXCore.xcframework.zip",
+	"3.9.0": "https://github.com/muxinc/stats-sdk-objc/releases/download/v3.9.0/MUXCore.xcframework.zip"
 }
 


### PR DESCRIPTION
Currently 3.9.0 in JSON file targets 3.8.0 tag, I don't think it is correct. I would also appreciate having 3.7.0 published there 🙂