### PR TITLE
fix: include SPM manifest with tools version 5.8

### DIFF
--- a/Package@swift-5.8.swift
+++ b/Package@swift-5.8.swift
@@ -1,0 +1,17 @@
+// swift-tools-version:5.8
+
+import PackageDescription
+
+let package = Package(
+    name: "MuxCore",
+    platforms: [
+        .iOS(.v11),
+        .tvOS(.v11),
+    ],
+    products: [
+        .library(name: "MuxCore", targets: ["MuxCore"])
+    ],
+    targets: [
+        .binaryTarget(name: "MuxCore", path: "XCFramework/MuxCore.xcframework")
+    ]
+)


### PR DESCRIPTION
## Fixes

Include SPM manifest that supports Swift tools version 5.8 for Xcode 14 compatibility.