### PR TITLE
Releases/v5.5.1

### DIFF
--- a/MUXCore.json
+++ b/MUXCore.json
@@ -32,7 +32,8 @@
     "5.3.1": "https://github.com/muxinc/stats-sdk-objc/releases/download/v5.3.1/MUXCore.xcframework.zip",
     "5.4.0": "https://github.com/muxinc/stats-sdk-objc/releases/download/v5.4.0/MUXCore.xcframework.zip",
     "5.4.1": "https://github.com/muxinc/stats-sdk-objc/releases/download/v5.4.1/MUXCore.xcframework.zip",
-    "5.5.0": "https://github.com/muxinc/stats-sdk-objc/releases/download/v5.5.0/MuxCore.xcframework.zip"
+    "5.5.0": "https://github.com/muxinc/stats-sdk-objc/releases/download/v5.5.0/MuxCore.xcframework.zip",
+    "5.5.1": "https://github.com/muxinc/stats-sdk-objc/releases/download/v5.5.1/MuxCore.xcframework.zip"
 }
 
 

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "MuxCore",
-            url: "https://github.com/muxinc/stats-sdk-objc/releases/download/v5.5.0/MuxCore.xcframework.zip",
-            checksum: "d60a8f241d64224d446d80f14c9387310429ec1b8e71a6a9b69275a918c0a05f"),
+            url: "https://github.com/muxinc/stats-sdk-objc/releases/download/v5.5.1/MuxCore.xcframework.zip",
+            checksum: "0519d609b35d4a988c7893e77bee0354a642a554c54612d23c2f258d25e0f2ee"),
     ]
 )


### PR DESCRIPTION
* Removes the deprecation on `MUXSDKCustomerVideoData.videoCDN` (added in v5.5.0)