### PR TITLE
Releases/v5.6.0

### DIFF
--- a/MUXCore.json
+++ b/MUXCore.json
@@ -33,7 +33,6 @@
     "5.4.0": "https://github.com/muxinc/stats-sdk-objc/releases/download/v5.4.0/MUXCore.xcframework.zip",
     "5.4.1": "https://github.com/muxinc/stats-sdk-objc/releases/download/v5.4.1/MUXCore.xcframework.zip",
     "5.5.0": "https://github.com/muxinc/stats-sdk-objc/releases/download/v5.5.0/MuxCore.xcframework.zip",
-    "5.5.1": "https://github.com/muxinc/stats-sdk-objc/releases/download/v5.5.1/MuxCore.xcframework.zip"
+    "5.5.1": "https://github.com/muxinc/stats-sdk-objc/releases/download/v5.5.1/MuxCore.xcframework.zip",
+    "5.6.0": "https://github.com/muxinc/stats-sdk-objc/releases/download/v5.6.0/MuxCore.xcframework.zip"
 }
-
-

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "MuxCore",
-            url: "https://github.com/muxinc/stats-sdk-objc/releases/download/v5.5.1/MuxCore.xcframework.zip",
-            checksum: "0519d609b35d4a988c7893e77bee0354a642a554c54612d23c2f258d25e0f2ee"),
+            url: "https://github.com/muxinc/stats-sdk-objc/releases/download/v5.6.0/MuxCore.xcframework.zip",
+            checksum: "4f93d008803a08c3e51c252eb48ab71d0f173cdb2cfe99e8fdeed3c0ff981e68"),
     ]
 )


### PR DESCRIPTION
## Improvements:
- Allow disabling playhead-based rebuffer tracking via `-[MUXSDKCore disablePlayheadRebufferTrackingForPlayerID:]` and manual dispatch of `MUXSDKRebufferStartEvent` and `MUXSDKRebufferEndEvent`

## Fixes:
- Prevent overriding `muxEmbed`, `muxEmbedVersion`, and `muxApiVersion` from `MUXSDKEnvironmentData`
- Individual frameworks within the XCFramework are no longer separately code signed. The parent XCFramework is still signed.