### PR TITLE
Releases/v5.7.1

### DIFF
--- a/MUXCore.json
+++ b/MUXCore.json
@@ -35,5 +35,6 @@
     "5.5.0": "https://github.com/muxinc/stats-sdk-objc/releases/download/v5.5.0/MuxCore.xcframework.zip",
     "5.5.1": "https://github.com/muxinc/stats-sdk-objc/releases/download/v5.5.1/MuxCore.xcframework.zip",
     "5.6.0": "https://github.com/muxinc/stats-sdk-objc/releases/download/v5.6.0/MuxCore.xcframework.zip",
-    "5.7.0": "https://github.com/muxinc/stats-sdk-objc/releases/download/v5.7.0/MuxCore.xcframework.zip"
+    "5.7.0": "https://github.com/muxinc/stats-sdk-objc/releases/download/v5.7.0/MuxCore.xcframework.zip",
+    "5.7.1": "https://github.com/muxinc/stats-sdk-objc/releases/download/v5.7.1/MuxCore.xcframework.zip"
 }

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "MuxCore",
-            url: "https://github.com/muxinc/stats-sdk-objc/releases/download/v5.7.0/MuxCore.xcframework.zip",
-            checksum: "93e763e1bab3b35e9e760fe48fb9f3408c1539edda97d395a85143a9f11e0027"),
+            url: "https://github.com/muxinc/stats-sdk-objc/releases/download/v5.7.1/MuxCore.xcframework.zip",
+            checksum: "c737ef893910eb8d54b1b28417a96178e775153970478fd83cc4354a93e6d8f1"),
     ]
 )


### PR DESCRIPTION
## Fixes
* Ensure `playbackmodechange` events are sent
* Restores tvOS-specific seeking detection behavior, where a best-effort attempt is made to count the preceding pause as part of the seek. This behavior was missing in 5.7.0, potentially causing changes in metrics.