### PR TITLE
Releases/v5.11.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "MuxCore",
-            url: "https://github.com/muxinc/stats-sdk-objc/releases/download/v5.10.0/MuxCore.xcframework.zip",
-            checksum: "d62dae165b641260588a280a2903a0f6ab9dcc101bc5bef78ae4a97fa15177b2"),
+            url: "https://github.com/muxinc/stats-sdk-objc/releases/download/v5.11.0/MuxCore.xcframework.zip",
+            checksum: "6fd1a88786ea0ed6c418a801b0c20682905ed3edace1b909eace91575e434d7e"),
     ]
 )


### PR DESCRIPTION
## Improvements
- Track ranges of content played during a view via `video_playback_range` metric

## Fixes
- Resolves an issue where setting `+[MUXSDKCore disablePlayheadRebufferTrackingForPlayerID:]` could have no effect
- `view_dropped_frame_count` is now reported (from both `MUXSDKVideoData.videoSourceFrameDrops` and `MUXSDKViewData.viewDroppedFramesCount`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a dependency version bump in `Package.swift`, with no source-code logic changes in this repo. Risk is limited to any behavioral changes in the updated prebuilt XCFramework.
> 
> **Overview**
> Updates the SwiftPM `binaryTarget` for `MuxCore` to download the v5.11.0 `MuxCore.xcframework` release (and refreshes the corresponding checksum), replacing v5.10.0.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 634b2ca8559fc4c999794135948fcd73ef20f010. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->